### PR TITLE
Fix: Resolve Hero Title Overlapping Description and Ensure Responsive…

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -207,6 +207,7 @@ p {
     font-size: 3.8rem;  /* Increase for impact */
     font-weight: 700;   /* Make it bolder */
     letter-spacing: -1px; /* Optional: Tighten spacing for large display text */
+    margin-bottom: 2rem; /* Added margin-bottom to prevent overlap with description */
 }
 
 /* Typography Enhancements - Profile Description */
@@ -274,6 +275,7 @@ h1.work { /* This combines previous spacing with new typography */
     .page-header .profile-title {
         font-size: 2.5rem; /* Reduce hero title size (was 2.8rem, adjusted) */
         text-align: center; /* Ensure title is centered */
+        margin-bottom: 1.5rem; /* Adjusted from 2rem for smaller screens */
     }
 
     .page-header .profile-description {
@@ -345,6 +347,7 @@ h1.work { /* This combines previous spacing with new typography */
 
     .page-header .profile-title {
         font-size: 2rem; /* (was 2.2rem, adjusted) */
+        margin-bottom: 1rem; /* Further reduce for extra small screens */
     }
 
     .page-header .profile-description {


### PR DESCRIPTION
…ness

I corrected a layout issue in the hero section where the main title (`h1.profile-title`) was overlapping the profile description (`p.profile-description`) below it.

- I increased the `margin-bottom` of `.page-header .profile-title` to `2rem` to provide adequate spacing on larger screens.
- I added responsive adjustments for this margin on smaller screens:
    - Set to `1.5rem` for tablets and below (`max-width: 767.98px`).
    - Set to `1rem` for extra small screens (`max-width: 575.98px`).

These changes ensure proper visual separation between the elements and maintain a balanced layout across various device sizes. All modifications were made in `assets/css/style.css`.